### PR TITLE
JSON slash comment structure not valid

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {


### PR DESCRIPTION
JSON files do not support // comments.
This was likely autogenerated from VScode.

Removed to validate JSON data structure. 



